### PR TITLE
Use http instead of https for kcm feed

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,7 +22,7 @@ services:
             description: King County, Washington
             gtfs:
               static:
-                url: https://metro.kingcounty.gov/GTFS/google_transit.zip
+                url: http://metro.kingcounty.gov/GTFS/google_transit.zip
               rtTripUpdates:
                 url: https://s3.amazonaws.com/kcm-alerts-realtime-prod/tripupdates.pb
     # 👇 Alternative way to provide feeds configuration


### PR DESCRIPTION
It looks like the kcm doesn't support https, switching to http works tho