### PR TITLE
fix(onebusaway): reject implausible realtime predictions

### DIFF
--- a/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
+++ b/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
@@ -35,7 +35,7 @@ export interface Name {
 }
 
 interface ArrivalsAndDeparturesResponse {
-  arrivalsAndDepartures: OnebusawaySDK.ArrivalAndDeparture.ArrivalAndDepartureListResponse.Data.Entry.ArrivalsAndDeparture[]
+  arrivalsAndDepartures: OBAArrivalsAndDeparture[]
   references: {
     stops: {
       [
@@ -68,6 +68,9 @@ function latLonSpanToBounds(
     latCenter + latSpan / 2,
   ]
 }
+
+type OBAArrivalsAndDeparture =
+  OnebusawaySDK.ArrivalAndDeparture.ArrivalAndDepartureListResponse.Data.Entry.ArrivalsAndDeparture
 
 @RegisterFeedProvider("onebusaway")
 export class OneBusAwayService implements FeedProvider {
@@ -465,49 +468,8 @@ export class OneBusAwayService implements FeedProvider {
           continue
         }
 
-        const scheduledDepartureTime = new Date(ad.scheduledDepartureTime)
-        const scheduledArrivalTime = new Date(ad.scheduledArrivalTime)
-        const hasPredictedTime =
-          !!ad.predictedArrivalTime || !!ad.predictedDepartureTime
-        let isRealtime = (ad.predicted ?? false) && hasPredictedTime
-        let departureTime =
-          isRealtime && ad.predictedDepartureTime
-            ? new Date(ad.predictedDepartureTime)
-            : scheduledDepartureTime
-        let arrivalTime =
-          isRealtime && ad.predictedArrivalTime
-            ? new Date(ad.predictedArrivalTime)
-            : scheduledArrivalTime
-
-        const maximumDeviationFromSchedule = Math.max(
-          Math.abs(departureTime.getTime() - scheduledDepartureTime.getTime()),
-          Math.abs(arrivalTime.getTime() - scheduledArrivalTime.getTime()),
-        )
-
-        if (maximumDeviationFromSchedule > ms("90m")) {
-          const scheduleDeviation = ad.tripStatus?.scheduleDeviation
-          const hasPlausibleScheduleDeviation =
-            ad.tripStatus?.predicted === true &&
-            ad.tripStatus.activeTripId === ad.tripId &&
-            typeof scheduleDeviation === "number" &&
-            Number.isFinite(scheduleDeviation) &&
-            Math.abs(scheduleDeviation * 1000) <= ms("90m")
-
-          if (hasPlausibleScheduleDeviation) {
-            // Preserve usable real-time information when OneBusAway returns a
-            // malformed absolute timestamp but a plausible schedule deviation.
-            departureTime = new Date(
-              scheduledDepartureTime.getTime() + scheduleDeviation * 1000,
-            )
-            arrivalTime = new Date(
-              scheduledArrivalTime.getTime() + scheduleDeviation * 1000,
-            )
-          } else {
-            departureTime = scheduledDepartureTime
-            arrivalTime = scheduledArrivalTime
-            isRealtime = false
-          }
-        }
+        const { departureTime, arrivalTime, isRealtime } =
+          this.resolveTripTimes(ad)
 
         if (departureTime.getTime() < this.dateTime.now().getTime()) {
           continue
@@ -551,5 +513,59 @@ export class OneBusAwayService implements FeedProvider {
     }
 
     return tripStops
+  }
+
+  private resolveTripTimes(ad: DeepReadonly<OBAArrivalsAndDeparture>) {
+    const scheduledDepartureTime = new Date(ad.scheduledDepartureTime)
+    const scheduledArrivalTime = new Date(ad.scheduledArrivalTime)
+    const hasPredictedTime =
+      !!ad.predictedArrivalTime || !!ad.predictedDepartureTime
+
+    let isRealtime = (ad.predicted ?? false) && hasPredictedTime
+
+    let departureTime =
+      isRealtime && ad.predictedDepartureTime
+        ? new Date(ad.predictedDepartureTime)
+        : scheduledDepartureTime
+
+    let arrivalTime =
+      isRealtime && ad.predictedArrivalTime
+        ? new Date(ad.predictedArrivalTime)
+        : scheduledArrivalTime
+
+    const maximumDeviationFromSchedule = Math.max(
+      Math.abs(departureTime.getTime() - scheduledDepartureTime.getTime()),
+      Math.abs(arrivalTime.getTime() - scheduledArrivalTime.getTime()),
+    )
+
+    const deviationConfidenceThreshold = ms("90m")
+
+    if (maximumDeviationFromSchedule > deviationConfidenceThreshold) {
+      const scheduleDeviation = ad.tripStatus?.scheduleDeviation
+
+      const hasPlausibleScheduleDeviation =
+        ad.tripStatus?.predicted === true &&
+        ad.tripStatus.activeTripId === ad.tripId &&
+        typeof scheduleDeviation === "number" &&
+        Number.isFinite(scheduleDeviation) &&
+        Math.abs(scheduleDeviation * 1000) <= deviationConfidenceThreshold
+
+      if (hasPlausibleScheduleDeviation) {
+        // Preserve usable real-time information when OneBusAway returns a
+        // malformed absolute timestamp but a plausible schedule deviation.
+        departureTime = new Date(
+          scheduledDepartureTime.getTime() + scheduleDeviation * 1000,
+        )
+        arrivalTime = new Date(
+          scheduledArrivalTime.getTime() + scheduleDeviation * 1000,
+        )
+      } else {
+        departureTime = scheduledDepartureTime
+        arrivalTime = scheduledArrivalTime
+        isRealtime = false
+      }
+    }
+
+    return { departureTime, arrivalTime, isRealtime }
   }
 }

--- a/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
+++ b/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
@@ -488,6 +488,7 @@ export class OneBusAwayService implements FeedProvider {
           const scheduleDeviation = ad.tripStatus?.scheduleDeviation
           const hasPlausibleScheduleDeviation =
             ad.tripStatus?.predicted === true &&
+            ad.tripStatus.activeTripId === ad.tripId &&
             typeof scheduleDeviation === "number" &&
             Number.isFinite(scheduleDeviation) &&
             Math.abs(scheduleDeviation * 1000) <= ms("90m")

--- a/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
+++ b/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
@@ -485,11 +485,27 @@ export class OneBusAwayService implements FeedProvider {
         )
 
         if (maximumDeviationFromSchedule > ms("90m")) {
-          // OneBusAway can occasionally return malformed predicted timestamps.
-          // Treat implausible predictions as low confidence and use the schedule.
-          departureTime = scheduledDepartureTime
-          arrivalTime = scheduledArrivalTime
-          isRealtime = false
+          const scheduleDeviation = ad.tripStatus?.scheduleDeviation
+          const hasPlausibleScheduleDeviation =
+            ad.tripStatus?.predicted === true &&
+            typeof scheduleDeviation === "number" &&
+            Number.isFinite(scheduleDeviation) &&
+            Math.abs(scheduleDeviation * 1000) <= ms("90m")
+
+          if (hasPlausibleScheduleDeviation) {
+            // Preserve usable real-time information when OneBusAway returns a
+            // malformed absolute timestamp but a plausible schedule deviation.
+            departureTime = new Date(
+              scheduledDepartureTime.getTime() + scheduleDeviation * 1000,
+            )
+            arrivalTime = new Date(
+              scheduledArrivalTime.getTime() + scheduleDeviation * 1000,
+            )
+          } else {
+            departureTime = scheduledDepartureTime
+            arrivalTime = scheduledArrivalTime
+            isRealtime = false
+          }
         }
 
         if (departureTime.getTime() < this.dateTime.now().getTime()) {

--- a/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
+++ b/src/modules/feed/modules/one-bus-away/one-bus-away.service.ts
@@ -465,19 +465,36 @@ export class OneBusAwayService implements FeedProvider {
           continue
         }
 
-        const departureTime =
-          ad.predicted && ad.predictedDepartureTime
+        const scheduledDepartureTime = new Date(ad.scheduledDepartureTime)
+        const scheduledArrivalTime = new Date(ad.scheduledArrivalTime)
+        const hasPredictedTime =
+          !!ad.predictedArrivalTime || !!ad.predictedDepartureTime
+        let isRealtime = (ad.predicted ?? false) && hasPredictedTime
+        let departureTime =
+          isRealtime && ad.predictedDepartureTime
             ? new Date(ad.predictedDepartureTime)
-            : new Date(ad.scheduledDepartureTime)
+            : scheduledDepartureTime
+        let arrivalTime =
+          isRealtime && ad.predictedArrivalTime
+            ? new Date(ad.predictedArrivalTime)
+            : scheduledArrivalTime
+
+        const maximumDeviationFromSchedule = Math.max(
+          Math.abs(departureTime.getTime() - scheduledDepartureTime.getTime()),
+          Math.abs(arrivalTime.getTime() - scheduledArrivalTime.getTime()),
+        )
+
+        if (maximumDeviationFromSchedule > ms("90m")) {
+          // OneBusAway can occasionally return malformed predicted timestamps.
+          // Treat implausible predictions as low confidence and use the schedule.
+          departureTime = scheduledDepartureTime
+          arrivalTime = scheduledArrivalTime
+          isRealtime = false
+        }
 
         if (departureTime.getTime() < this.dateTime.now().getTime()) {
           continue
         }
-
-        const arrivalTime =
-          ad.predicted && ad.predictedArrivalTime
-            ? new Date(ad.predictedArrivalTime)
-            : new Date(ad.scheduledArrivalTime)
 
         const staticTrip = arrivalsAndDeparturesResp.references.trips[ad.tripId]
         const staticStop = arrivalsAndDeparturesResp.references.stops[stopId]
@@ -500,7 +517,7 @@ export class OneBusAwayService implements FeedProvider {
           ),
           arrivalTime,
           departureTime,
-          isRealtime: ad.predicted ?? false,
+          isRealtime,
         }
 
         if (existing) {

--- a/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
+++ b/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
@@ -336,7 +336,52 @@ describe("OneBusAwayService", () => {
       )
     })
 
-    it("falls back to scheduled times when predicted times are implausible", async () => {
+    it("uses a plausible schedule deviation when predicted times are implausible", async () => {
+      // Arrange & Act
+      const tripId = "1_766488949"
+      const scheduledTime = new Date("2026-06-26T21:50:00-07:00").getTime()
+      const invalidPredictedTime = new Date(
+        "2026-06-26T00:09:59-07:00",
+      ).getTime()
+      const scheduleDeviation = -420
+
+      const upcomingTrips = await getUpcomingTripsForTestRoutes((resp) => {
+        const arrivalAndDeparture = resp.data.entry.arrivalsAndDepartures.find(
+          (ad) => ad.tripId === tripId,
+        )
+
+        if (!arrivalAndDeparture) {
+          return resp
+        }
+
+        arrivalAndDeparture.predicted = true
+        arrivalAndDeparture.scheduledArrivalTime = scheduledTime
+        arrivalAndDeparture.scheduledDepartureTime = scheduledTime
+        arrivalAndDeparture.predictedArrivalTime = invalidPredictedTime
+        arrivalAndDeparture.predictedDepartureTime = invalidPredictedTime
+        arrivalAndDeparture.tripStatus = {
+          ...arrivalAndDeparture.tripStatus!,
+          predicted: true,
+          scheduleDeviation,
+        }
+
+        return resp
+      })
+
+      // Assert
+      const trip = upcomingTrips.find((trip) => trip.tripId === tripId)
+
+      expect(trip).toBeDefined()
+      expect(trip?.isRealtime).toBe(true)
+      expect(trip?.arrivalTime.getTime()).toBe(
+        scheduledTime + scheduleDeviation * 1000,
+      )
+      expect(trip?.departureTime.getTime()).toBe(
+        scheduledTime + scheduleDeviation * 1000,
+      )
+    })
+
+    it("falls back to scheduled times when all predictions are implausible", async () => {
       // Arrange & Act
       const tripId = "1_766488949"
       const invalidPredictedTime = new Date("2025-12-16T06:00:00Z").getTime()
@@ -357,6 +402,7 @@ describe("OneBusAwayService", () => {
         arrivalAndDeparture.predicted = true
         arrivalAndDeparture.predictedArrivalTime = invalidPredictedTime
         arrivalAndDeparture.predictedDepartureTime = invalidPredictedTime
+        arrivalAndDeparture.tripStatus = undefined
 
         return resp
       })

--- a/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
+++ b/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
@@ -336,7 +336,7 @@ describe("OneBusAwayService", () => {
       )
     })
 
-    it("uses a plausible schedule deviation when predicted times are implausible", async () => {
+    it("ignores a schedule deviation from a different active trip", async () => {
       // Arrange & Act
       const tripId = "1_766488949"
       const scheduledTime = new Date("2026-06-26T21:50:00-07:00").getTime()
@@ -361,6 +361,48 @@ describe("OneBusAwayService", () => {
         arrivalAndDeparture.predictedDepartureTime = invalidPredictedTime
         arrivalAndDeparture.tripStatus = {
           ...arrivalAndDeparture.tripStatus!,
+          activeTripId: "95_128606262621",
+          predicted: true,
+          scheduleDeviation,
+        }
+
+        return resp
+      })
+
+      // Assert
+      const trip = upcomingTrips.find((trip) => trip.tripId === tripId)
+
+      expect(trip).toBeDefined()
+      expect(trip?.isRealtime).toBe(false)
+      expect(trip?.arrivalTime.getTime()).toBe(scheduledTime)
+      expect(trip?.departureTime.getTime()).toBe(scheduledTime)
+    })
+
+    it("uses a plausible schedule deviation from the target trip", async () => {
+      // Arrange & Act
+      const tripId = "1_766488949"
+      const invalidPredictedTime = new Date("2025-12-16T06:00:00Z").getTime()
+      const scheduleDeviation = -420
+      let scheduledArrivalTime = 0
+      let scheduledDepartureTime = 0
+
+      const upcomingTrips = await getUpcomingTripsForTestRoutes((resp) => {
+        const arrivalAndDeparture = resp.data.entry.arrivalsAndDepartures.find(
+          (ad) => ad.tripId === tripId,
+        )
+
+        if (!arrivalAndDeparture) {
+          return resp
+        }
+
+        scheduledArrivalTime = arrivalAndDeparture.scheduledArrivalTime
+        scheduledDepartureTime = arrivalAndDeparture.scheduledDepartureTime
+        arrivalAndDeparture.predicted = true
+        arrivalAndDeparture.predictedArrivalTime = invalidPredictedTime
+        arrivalAndDeparture.predictedDepartureTime = invalidPredictedTime
+        arrivalAndDeparture.tripStatus = {
+          ...arrivalAndDeparture.tripStatus!,
+          activeTripId: tripId,
           predicted: true,
           scheduleDeviation,
         }
@@ -374,10 +416,10 @@ describe("OneBusAwayService", () => {
       expect(trip).toBeDefined()
       expect(trip?.isRealtime).toBe(true)
       expect(trip?.arrivalTime.getTime()).toBe(
-        scheduledTime + scheduleDeviation * 1000,
+        scheduledArrivalTime + scheduleDeviation * 1000,
       )
       expect(trip?.departureTime.getTime()).toBe(
-        scheduledTime + scheduleDeviation * 1000,
+        scheduledDepartureTime + scheduleDeviation * 1000,
       )
     })
 

--- a/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
+++ b/test/unit/modules/feed/one-bus-away/one-bus-away.service.spec.ts
@@ -336,6 +336,40 @@ describe("OneBusAwayService", () => {
       )
     })
 
+    it("falls back to scheduled times when predicted times are implausible", async () => {
+      // Arrange & Act
+      const tripId = "1_766488949"
+      const invalidPredictedTime = new Date("2025-12-16T06:00:00Z").getTime()
+      let scheduledArrivalTime = 0
+      let scheduledDepartureTime = 0
+
+      const upcomingTrips = await getUpcomingTripsForTestRoutes((resp) => {
+        const arrivalAndDeparture = resp.data.entry.arrivalsAndDepartures.find(
+          (ad) => ad.tripId === tripId,
+        )
+
+        if (!arrivalAndDeparture) {
+          return resp
+        }
+
+        scheduledArrivalTime = arrivalAndDeparture.scheduledArrivalTime
+        scheduledDepartureTime = arrivalAndDeparture.scheduledDepartureTime
+        arrivalAndDeparture.predicted = true
+        arrivalAndDeparture.predictedArrivalTime = invalidPredictedTime
+        arrivalAndDeparture.predictedDepartureTime = invalidPredictedTime
+
+        return resp
+      })
+
+      // Assert
+      const trip = upcomingTrips.find((trip) => trip.tripId === tripId)
+
+      expect(trip).toBeDefined()
+      expect(trip?.isRealtime).toBe(false)
+      expect(trip?.arrivalTime.getTime()).toBe(scheduledArrivalTime)
+      expect(trip?.departureTime.getTime()).toBe(scheduledDepartureTime)
+    })
+
     it("filters out trips which have already departed", async () => {
       // Arrange & Act
       const alreadyDepartedTripId = "1_766488949"


### PR DESCRIPTION
## Overview

This change prevents malformed OneBusAway realtime timestamps from causing valid upcoming trips to be filtered out as already departed.

When a predicted arrival or departure differs from its scheduled time by more than 90 minutes, the prediction is treated as low-confidence. A plausible `scheduleDeviation` is used only when the reported `activeTripId` matches the target trip. Otherwise, the scheduled arrival and departure are used and the trip is marked as non-realtime.

This mirrors the existing 90-minute confidence threshold used by the GTFS-Realtime provider while accounting for OneBusAway's additional trip-status data.

The issue was observed with Washington State Ferries. OneBusAway returned a scheduled Edmonds–Kingston departure at 9:50 PM with a malformed predicted departure of 12:09:59 AM. Transit Tracker trusted the prediction and filtered the sailing as already departed.

## Testing Strategy

Added unit coverage for:

- Plausible predicted arrival and departure times.
- Malformed absolute predictions with a same-trip, plausible schedule deviation.
- Malformed predictions whose schedule deviation belongs to a different active trip.
- Malformed predictions without any trustworthy realtime fallback.
- Existing filtering of trips that have actually departed.

The Washington State Ferries regression test uses the observed values:

- Scheduled departure: 9:50 PM
- Predicted departure: 12:09:59 AM
- Schedule deviation: -420 seconds
- Active trip: the reverse Kingston–Edmonds leg

Validation performed:

- Full unit suite: 196 tests passed across 20 test files.
- Production build completed successfully with zero TypeScript errors.
- Reproduced the original behavior against the public Puget Sound OneBusAway API and the hosted Transit Tracker API.

## Related Issue

Not related to an open issue.

## AI Assistance

These changes were AI-generated with Codex and developed iteratively with the user.

- [ ] Not made with any sort of AI assistance
- [ ] AI-assisted (GitHub Copilot autocomplete, Q&A to an out-of-band chatbot like ChatGPT, etc.)
- [x] AI-generated (Claude Code, Cursor, Codex etc.)

Codex investigated the live OneBusAway and Transit Tracker responses, traced the filtering behavior, implemented the fallback logic, added regression tests, and ran the test suite and production build. The user supplied the original observed behavior, reviewed the proposed behavior, tested the branch on a Raspberry Pi server deployment, and challenged the initial handling of `scheduleDeviation`, leading to the stricter same-trip validation.